### PR TITLE
feat: add start_frontend command and tools hatch environment

### DIFF
--- a/.claude/commands/start_frontend.md
+++ b/.claude/commands/start_frontend.md
@@ -1,0 +1,28 @@
+Launch the local frontend web UI for the dump-things-server.
+
+## Steps
+
+1. Check if the directory `_ext/pool.psychoinformatics.de-ui/` exists in the project root. If it does, skip to step 6.
+2. Clone the frontend repo:
+   ```
+   git clone https://hub.psychoinformatics.de/www/pool.psychoinformatics.de-ui _ext/pool.psychoinformatics.de-ui
+   ```
+3. Fetch all submodules within the cloned repo:
+   ```
+   cd _ext/pool.psychoinformatics.de-ui && git submodule update --init --recursive
+   ```
+4. Build the frontend:
+   ```
+   cd _ext/pool.psychoinformatics.de-ui && make install && make
+   ```
+5. Modify the file `_ext/pool.psychoinformatics.de-ui/dist/config.yaml`: set the `service_base_url` key to the following value:
+   ```yaml
+   service_base_url:
+     - url: http://localhost:8111/research_info/
+       type: write
+   ```
+6. Serve the frontend (this command is blocking):
+   ```
+   hatch run tools:serve-frontend
+   ```
+   The frontend will be available at http://localhost:8000.

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@
 store/**
 !store/**/
 !store/**/.dumpthings.yaml
+
+# External repo clones
+_ext

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,12 @@ dependencies = [
 [tool.hatch.envs.dump-server.scripts]
 start = 'dump-things-service --origins "http://localhost:8000" --host localhost --port 8111 "{root}/store"'
 
+[tool.hatch.envs.tools]
+installer = "uv"
+detached = true
+[tool.hatch.envs.tools.scripts]
+serve-frontend = 'python -m http.server --directory "{root}/_ext/pool.psychoinformatics.de-ui/dist" 8000'
+
 [tool.hatch.envs.types]
 extra-dependencies = [
   "mypy>=1.0.0",


### PR DESCRIPTION
This PR closes https://github.com/con/dump-research-info/issues/2.

Add a Claude Code slash command to clone, build, and serve the pool.psychoinformatics.de-ui frontend locally, pointed at the local dump-things-server. Add a detached hatch `tools` environment with a `serve-frontend` script.