### PR TITLE
refactor: migrate CLI framework from Click to Typer

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
 dependencies = [
-  "click",
+  "typer",
 ]
 
 [project.urls]
@@ -31,7 +31,7 @@ Issues = "https://github.com/Isaac To/dump-research-info/issues"
 Source = "https://github.com/Isaac To/dump-research-info"
 
 [project.scripts]
-dump-research-info = "dump_research_info.cli:dump_research_info"
+dump-research-info = "dump_research_info.cli:app"
 
 [tool.hatch.version]
 path = "src/dump_research_info/__about__.py"

--- a/src/dump_research_info/__main__.py
+++ b/src/dump_research_info/__main__.py
@@ -4,6 +4,6 @@
 import sys
 
 if __name__ == "__main__":
-    from dump_research_info.cli import dump_research_info
+    from dump_research_info.cli import app
 
-    sys.exit(dump_research_info())
+    sys.exit(app())

--- a/src/dump_research_info/cli/__init__.py
+++ b/src/dump_research_info/cli/__init__.py
@@ -1,12 +1,29 @@
 # SPDX-FileCopyrightText: 2026-present Isaac To <candleindark@gmail.com>
 #
 # SPDX-License-Identifier: MIT
-import click
+import typer
 
 from dump_research_info.__about__ import __version__
 
 
-@click.group(context_settings={"help_option_names": ["-h", "--help"]}, invoke_without_command=True)
-@click.version_option(version=__version__, prog_name="dump-research-info")
-def dump_research_info():
-    click.echo("Hello world!")
+def version_callback(value: bool) -> None:
+    if value:
+        typer.echo(__version__)
+        raise typer.Exit()
+
+
+app = typer.Typer()
+
+
+@app.callback(invoke_without_command=True)
+def main(
+    version: bool = typer.Option(
+        False,
+        "--version",
+        "-V",
+        callback=version_callback,
+        is_eager=True,
+        help="Show version and exit.",
+    ),
+) -> None:
+    typer.echo("Hello world!")


### PR DESCRIPTION
This pull request migrates the CLI from Click to Typer, updating both the dependencies and the implementation to use Typer's interface. The entry point for the CLI is also updated to use the new Typer app.

**CLI Framework Migration:**

* Replaced the `click` dependency with `typer` in the project dependencies and switched all CLI logic from Click decorators to Typer's API in `cli/__init__.py`. [[1]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L25-R25) [[2]](diffhunk://#diff-b06cc9111a94f699eb57b3894adb1464b3f3baaa629954bde7abaa1a30273c8fL4-R29)
* Updated the main CLI entry point from `dump_research_info` to `app` in both the script entry definition in `pyproject.toml` and the `__main__.py` file. [[1]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L34-R34) [[2]](diffhunk://#diff-bb3247b4fcfda40142bc60fe1459ed20016cdb729cfde6c870d9581b784f55e7L7-R9)

**Version Option Handling:**

* Implemented a version callback using Typer's option system to display the version and exit, replacing Click's version option mechanism.