### PR TITLE
fix: limit connection pool concurrency and improve RequestError messages

### DIFF
--- a/src/dump_research_info/dump.py
+++ b/src/dump_research_info/dump.py
@@ -27,7 +27,10 @@ async def _post_record(
             headers={"X-DumpThings-Token": token},
         )
     except httpx.RequestError as e:
-        return str(e)
+        msg = type(e).__name__
+        if details := str(e):
+            msg += f": {details}"
+        return msg
 
     try:
         response.raise_for_status()


### PR DESCRIPTION
## Summary

- Cap `httpx.AsyncClient` to 50 simultaneous connections
  (`max_connections=50`) and disable the pool timeout (`pool=None`)
  so that excess requests queue up instead of raising `PoolTimeout`
  when uploading large batches of records concurrently.
- Include the exception class name in `httpx.RequestError` error
  messages, since many subclasses (e.g. `PoolTimeout`) have an empty
  string representation that makes failures hard to diagnose.

## Test plan

- [x] Run `dump-research-info` against a local dump-things-server
  with a large dataset (700+ records) and confirm no `PoolTimeout`
  errors occur.
- [x] Verify that request errors are reported with a non-empty,
  informative message (e.g. `PoolTimeout`, `ConnectError: ...`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)