### PR TITLE
docs: document two frontend variants in start_frontend

### DIFF
--- a/.claude/commands/start_frontend.md
+++ b/.claude/commands/start_frontend.md
@@ -15,7 +15,15 @@ Launch the local frontend web UI for the dump-things-server.
    ```
    cd _ext/pool.psychoinformatics.de-ui && make install && make
    ```
-5. Modify the file `_ext/pool.psychoinformatics.de-ui/dist/config.yaml`: set the `service_base_url` key to the following value:
+5. The build produces two application variants, each in its own
+   subdirectory of `dist/` with its own copy of the configuration:
+   - `dist/ui/`: the main knowledge pooling tool
+   - `dist/kickstarter/`: the "knowledge kickstarter" variant
+
+   In **both** `_ext/pool.psychoinformatics.de-ui/dist/ui/config.yaml` and
+   `_ext/pool.psychoinformatics.de-ui/dist/kickstarter/config.yaml`, replace
+   the `service_base_url` key (which by default lists the production
+   `pool.psychoinformatics.de` endpoints) with the following value:
    ```yaml
    service_base_url:
      - url: http://localhost:8111/research_info/
@@ -25,4 +33,11 @@ Launch the local frontend web UI for the dump-things-server.
    ```
    hatch run tools:serve-frontend
    ```
-   The frontend will be available at http://localhost:8000.
+   This serves the whole `dist/` directory, so that both variants are
+   reachable under their own subpaths, mirroring the layout of the
+   production deployment at https://pool.psychoinformatics.de/:
+   - http://localhost:8000/ui/
+   - http://localhost:8000/kickstarter/
+
+   Note that there is no application at the server root
+   (http://localhost:8000/); it only lists the two subdirectories.

--- a/README.md
+++ b/README.md
@@ -78,7 +78,13 @@ and
   JSON files in `data/<source_name>/`.
 - **`/start_frontend`** — Launch the local frontend web UI for the
   dump-things-server. This command handles cloning and building the
-  frontend repo (if needed) and serving it on `http://localhost:8000`.
+  frontend repo (if needed), pointing it at the local backend, and
+  serving it on `http://localhost:8000`. The build provides two
+  application variants, which are served under separate subpaths, just
+  as they are on the production deployment at
+  <https://pool.psychoinformatics.de/>: the main knowledge pooling tool
+  at `http://localhost:8000/ui/` and the knowledge kickstarter at
+  `http://localhost:8000/kickstarter/`.
 
 ## License
 


### PR DESCRIPTION
## Summary

Upstream `pool.psychoinformatics.de-ui` now builds two application variants instead of one, so the `/start_frontend` command and its `README.md` description were out of date. This PR updates the docs to match the current build layout.

- The build produces `dist/ui/` (the knowledge pooling tool) and `dist/kickstarter/` (the knowledge kickstarter), each with its own `config.yaml`. There is no longer a single `dist/config.yaml`.
- `tools:serve-frontend` serves the whole `dist/` directory, so the variants are reachable at `http://localhost:8000/ui/` and `http://localhost:8000/kickstarter/`, mirroring the production deployment at <https://pool.psychoinformatics.de/>. The server root only lists the two subdirectories.

## Changes

- `.claude/commands/start_frontend.md`: step 5 now points at both `dist/ui/config.yaml` and `dist/kickstarter/config.yaml` for the `service_base_url` edit; step 6 documents the `/ui/` and `/kickstarter/` subpaths and the empty server root.
- `README.md`: the `/start_frontend` entry describes the two variants and their subpaths.

Docs-only; no code changes.

## Test plan

- [x] Cloned and built the frontend per the updated steps; both configs patched and both variants served.
- [x] Verified `http://localhost:8000/ui/` and `http://localhost:8000/kickstarter/` return `200`, and both `config.yaml` files point at the local backend.
