### PR TITLE
test: match CLI help argument names case-insensitively

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -18,8 +18,12 @@ class TestCLIInfo:
     def test_help(self):
         result = runner.invoke(app, ["--help"])
         assert result.exit_code == 0
-        for expected in ["SOURCE", "SERVICE_URL", "--token", "--collection", "--dry-run"]:
-            assert expected in result.output
+        # Match case-insensitively: Typer renders positional-argument names in
+        # lowercase in its Rich help, and the exact casing is a cosmetic detail
+        # that has changed across Typer releases.
+        output = result.output.lower()
+        for expected in ["source", "service_url", "--token", "--collection", "--dry-run"]:
+            assert expected in output
 
     @pytest.mark.parametrize(
         "extra_args",


### PR DESCRIPTION
## Summary

`TestCLIInfo.test_help` is failing in CI on `main` (and therefore on every open PR). The failure is unrelated to any code change: it is caused by an unpinned `typer` dependency picking up a newer release whose Rich help output renders positional-argument names in lowercase.

The test asserted that the `--help` output contained the argument metavars as `SOURCE` and `SERVICE_URL`. Current Typer renders them as `source` and `service_url` in the Arguments panel (and `{source} {service_url}` in the usage line), so those two assertions fail. The `--token`, `--collection`, and `--dry-run` option checks were unaffected.

## Fix

Lowercase the captured help output and match the argument names case-insensitively. The exact casing of the rendered metavars is a cosmetic Typer detail that has changed across releases, and the test only means to confirm the arguments and options are surfaced in `--help`.

## Test plan

- [x] `hatch run test:run` passes locally (24 passed) with the current, unpinned Typer that reproduces the CI failure.
- [x] Confirmed the pre-fix assertions fail against the same environment.

## Note

The underlying cause is that `typer` (and the other runtime deps) are unpinned in `pyproject.toml`, so CI behavior can drift whenever upstream releases. Pinning or adding upper bounds would prevent this class of surprise, but that is a broader decision left out of this focused fix.
